### PR TITLE
Improve locking in CriticalSection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ The annotation `@WfdMeta\Send304IfNotModified` allows to return a special 304 re
 There is also a Controller-as-a-service `webfactory_wfd_meta.controller.template`, which is similar to the [TemplateController des FrameworkBundle](http://symfony.com/doc/current/cookbook/templating/render_without_controller.html) but also considers `wfd_meta` information.
 
 ## Installation ##
+
 The bundle is installed like any other Symfony2 bundle.
+
+## Tests ##
+
+Run the tests with
+
+    vendor/bin/phpunit
 
 ## Credits, Copyright and License ##
 

--- a/Tests/Util/CriticalSectionTest.php
+++ b/Tests/Util/CriticalSectionTest.php
@@ -52,6 +52,9 @@ class CriticalSectionTest extends \PHPUnit_Framework_TestCase
         $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', $this->createCallbackThatMustBeInvoked());
     }
 
+    /**
+     *  This ensures that the critical section is re-entrant as documented.
+     */
     public function testCallbackCanAcquireSameLockAgain()
     {
         $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', function () {

--- a/Tests/Util/CriticalSectionTest.php
+++ b/Tests/Util/CriticalSectionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Webfactory\Bundle\WfdMetaBundle\Tests\Util;
+
+use Webfactory\Bundle\WfdMetaBundle\Util\CriticalSection;
+
+class CriticalSectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * System under test.
+     *
+     * @var CriticalSection
+     */
+    private $criticalSection = null;
+
+    /**
+     * Initializes the test environment.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->criticalSection = new CriticalSection();
+    }
+
+    /**
+     * Cleans up the test environment.
+     */
+    protected function tearDown()
+    {
+        $this->criticalSection = null;
+        parent::tearDown();
+    }
+
+    public function testExecuteReturnsValueFromCallback()
+    {
+        $result = $this->criticalSection->execute(__DIR__ . '/my/virtual/file', function () {
+            return 42;
+        });
+
+        $this->assertEquals(42, $result);
+    }
+
+    public function testInvokesCallbacksWithDifferentLocks()
+    {
+        $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', $this->createCallbackThatMustBeInvoked());
+        $this->criticalSection->execute(__DIR__ . '/my/virtual/file2', $this->createCallbackThatMustBeInvoked());
+    }
+
+    public function testInvokesCallbackWithSameLock()
+    {
+        $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', $this->createCallbackThatMustBeInvoked());
+        $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', $this->createCallbackThatMustBeInvoked());
+    }
+
+    public function testCallbackCanAcquireSameLockAgain()
+    {
+        $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', function () {
+            $this->criticalSection->execute(__DIR__ . '/my/virtual/file1', $this->createCallbackThatMustBeInvoked());
+        });
+    }
+
+    /**
+     * Creates a closure that must be called, otherwise the test fails.
+     *
+     * @return \Closure
+     */
+    private function createCallbackThatMustBeInvoked()
+    {
+        $mock = $this->getMock(\stdClass::class, array('__invoke'));
+        $mock->expects($this->once())
+            ->method('__invoke');
+        return function () use ($mock) {
+            call_user_func($mock);
+        };
+    }
+}

--- a/Util/CriticalSection.php
+++ b/Util/CriticalSection.php
@@ -8,17 +8,16 @@
 
 namespace Webfactory\Bundle\WfdMetaBundle\Util;
 
+use Symfony\Component\Filesystem\LockHandler;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
  * Stellt sicher, dass ein bestimmter Code-Abschnitt *von unterschiedlichen Prozessen
- * auf dem gleichen System* sequentiell durchlaufen wird. Braucht System V Semaphores
- * aus der PHP pcntl-Extension.
+ * auf dem gleichen System* sequentiell durchlaufen wird.
  *
- * Basis der Synchronisation ist eine Datei, die an execute() übergeben wird und die
- * existieren muss. Alle Prozesse, die CriticalSection auf Basis der gleichen Datei
- * ausführen, werden synchronisiert - unabhängig davon, was sie im callback
- * tun.
+ * Basis der Synchronisation ist eine Datei, die an execute() übergeben wird. Alle
+ * Prozesse, die CriticalSection auf Basis der gleichen Datei ausführen, werden
+ * synchronisiert - unabhängig davon, was sie im callback tun.
  *
  * CriticalSection ist re-entrant, d. h. wenn ein Prozess seinen callback zur Ausführung
  * bringt kann er für die gleiche Synchronisationsdatei weitere CriticalSection-Aufrufe
@@ -26,18 +25,37 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  */
 class CriticalSection
 {
-
-    protected static $entranceCount = array();
-    protected static $semaphore = array();
+    /**
+     * List of active locks.
+     *
+     * The lock name is used as key.
+     *
+     * @var array<string, LockHandler>
+     */
+    protected static $locks = array();
 
     /**
-     * @var LoggerInterface
+     * Counts how often a specific lock was requested.
+     *
+     * The lock name is used as key.
+     *
+     * @var array<string, integer>
      */
-    protected $logger;
+    protected static $entranceCount = array();
 
-    public function setLogger(LoggerInterface $l)
+    /**
+     * @var LoggerInterface|null
+     */
+    protected $logger = null;
+
+    /**
+     * Sets a logger that is used to send debugging messages.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
     {
-        $this->logger = $l;
+        $this->logger = $logger;
     }
 
     /**
@@ -47,44 +65,69 @@ class CriticalSection
      */
     public function execute($file, \Closure $callback)
     {
-        $tok = ftok($file, 'x');
-
-        self::lock($tok);
-
+        self::lock($file);
         try {
             return $callback();
         } finally {
-            self::release($tok);
+            self::release($file);
         }
     }
 
-    protected function lock($tok)
+    /**
+     * @param string $lockName
+     */
+    protected function lock($lockName)
     {
-        if (!isset(self::$entranceCount[$tok]) || !self::$entranceCount[$tok]) {
-            $this->debug("Waiting for the lock $tok");
-            sem_acquire(self::$semaphore[$tok] = sem_get($tok));
-            $this->debug("Obtained the lock $tok");
-            self::$entranceCount[$tok] = 0;
+        $this->debug("Requesting lock $lockName");
+        if (!$this->getLock($lockName)->lock(true)) {
+            $this->debug("Failed to get lock $lockName");
+            throw new \RuntimeException("Failed to get lock $lockName");
         }
-
-        self::$entranceCount[$tok]++;
+        if (!isset(self::$entranceCount[$lockName])) {
+            self::$entranceCount[$lockName] = 0;
+        }
+        self::$entranceCount[$lockName]++;
+        $this->debug("Obtained the lock $lockName");
     }
 
-    protected function release($tok)
+    /**
+     * @param string $lockName
+     */
+    protected function release($lockName)
     {
-        self::$entranceCount[$tok]--;
-
-        if (!self::$entranceCount[$tok]) {
-            $this->debug("Releasing the lock $tok");
-            sem_release(self::$semaphore[$tok]);
+        self::$entranceCount[$lockName]--;
+        if (self::$entranceCount[$lockName] === 0) {
+            $this->debug("Releasing the lock $lockName");
+            $this->getLock($lockName)->release();
         }
     }
 
-    protected function debug($msg)
+    /**
+     * Returns the lock with the provided name.
+     *
+     * A new lock object will be created if it does not exist yet.
+     * This method will *not* automatically acquire the lock.
+     *
+     * @param string $name
+     * @return LockHandler
+     */
+    protected function getLock($name)
+    {
+        if (!isset(self::$locks[$name])) {
+            self::$locks[$name] = new LockHandler($name);
+        }
+        return self::$locks[$name];
+    }
+
+    /**
+     * Logs the given message if a logger is available.
+     *
+     * @param string $message
+     */
+    protected function debug($message)
     {
         if ($this->logger) {
-            $this->logger->debug($msg, array('pid' => getmypid()));
+            $this->logger->debug($message, array('pid' => getmypid()));
         }
     }
-
 }

--- a/Util/CriticalSection.php
+++ b/Util/CriticalSection.php
@@ -40,6 +40,11 @@ class CriticalSection
         $this->logger = $l;
     }
 
+    /**
+     * @param string $file
+     * @param \Closure $callback
+     * @return mixed Return value of the callback.
+     */
     public function execute($file, \Closure $callback)
     {
         $tok = ftok($file, 'x');

--- a/Util/CriticalSection.php
+++ b/Util/CriticalSection.php
@@ -41,7 +41,7 @@ class CriticalSection
     }
 
     /**
-     * @param string $file
+     * @param string $file File path that is used as lock name.
      * @param \Closure $callback
      * @return mixed Return value of the callback.
      */

--- a/Util/CriticalSection.php
+++ b/Util/CriticalSection.php
@@ -46,19 +46,11 @@ class CriticalSection
 
         self::lock($tok);
 
-        $e = null;
         try {
-            $r = $callback();
-        } catch (\Exception $e) { /* fake finally {} */
+            return $callback();
+        } finally {
+            self::release($tok);
         }
-
-        self::release($tok);
-
-        if ($e) {
-            throw $e;
-        }
-
-        return $r;
     }
 
     protected function lock($tok)

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "symfony/symfony": "~2.7",
         "symfony/monolog-bundle": "~2.2",
         "symfony/framework-bundle": "~2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
 
     "require": {
+        "php": "^5.5.0 | ^7.0.0",
         "symfony/symfony": "~2.7",
         "symfony/monolog-bundle": "~2.2",
         "symfony/framework-bundle": "~2.2"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
+
+    <testsuites>
+        <testsuite name="Full test suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <!-- Filter for code coverage -->
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory>Resources</directory>
+                <directory>Tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
Replaces locking via [semaphores](http://php.net/manual/en/function.sem-acquire.php) in CriticalSection by file locks via [Symfony LockHandler](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Filesystem/LockHandler.php).

Avoids problems that result from too many open semaphores as the previous code released semaphores, but never removed them.