### PR TITLE
Fix missing chmod call for .wfd_meta file

### DIFF
--- a/Config/WfdMetaConfigCache.php
+++ b/Config/WfdMetaConfigCache.php
@@ -102,9 +102,13 @@ class WfdMetaConfigCache implements ConfigCacheInterface
         $mode = 0666;
         $umask = umask();
         $filesystem = new Filesystem();
-        $filesystem->dumpFile($this->file . '.wfd_meta', $content, null);
+
+        $filename = $this->file . '.wfd_meta';
+
+        $filesystem->dumpFile($filename, $content, null);
+
         try {
-            $filesystem->chmod($this->file, $mode, $umask);
+            $filesystem->chmod($filename, $mode, $umask);
         } catch (IOException $e) {
             // discard chmod failure (some filesystem may not support it)
         }


### PR DESCRIPTION
Obviously a typo when copying code from `\Symfony\Component\Config\ResourceCheckerConfigCache::write`